### PR TITLE
feat : add speedtest functionality

### DIFF
--- a/cmd/speedtest.go
+++ b/cmd/speedtest.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/jlaffaye/ftp"
+	"github.com/spf13/cobra"
+)
+
+var uploadServerPoolCredentials = map[string]Credentials{
+	"ftp://ftp.dlptest.com": {
+		userName: "dlpuser",
+		password: "rNrKYTX9g7z3RgJRmxWuGHbeu",
+	},
+}
+
+// 定义扫描命令
+var speedTestCmd = &cobra.Command{
+	Use:   "speedtest",
+	Short: "Perform an internet speed test",
+	Long:  `Measure your internet connection's download and upload speeds using speedtest.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		speedTest()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(speedTestCmd)
+
+}
+func speedTest() {
+	var downloadServerPool = []string{
+		"https://speed.cloudflare.com/__down?bytes=104857600",
+		"https://sgp.proof.ovh.net/files/100Mb.dat",
+	}
+
+	var uploadServerPool = []string{
+		"ftp://ftp.dlptest.com",
+	}
+	fmt.Println("Starting download speed test...")
+	downloadSpeed, err := testDownloadSpeed(downloadServerPool[0])
+	if err != nil {
+		fmt.Printf("Error during download test: %v\n", err)
+		return
+	}
+	fmt.Println("Starting upload speed test...")
+	uploadSpeed, err := testUploadSpeed(uploadServerPool[0], uploadServerPoolCredentials[uploadServerPool[0]])
+
+	if err != nil {
+		fmt.Printf("Error during upload test: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Download Speed: %.2f Mbps\n", downloadSpeed)
+	fmt.Printf("Upload Speed: %.2f Mbps\n", uploadSpeed)
+}
+
+func isValid(urlStr string) bool {
+	_, err := url.Parse(urlStr)
+	return err == nil
+}
+
+func testDownloadSpeed(serverURL string) (float64, error) {
+	// 1. 验证URL合法性
+	if !isValid(serverURL) {
+		return 0, fmt.Errorf("invalid URL: %s", serverURL)
+	}
+
+	// 2. 初始化HTTP客户端
+	client := &http.Client{Timeout: 60 * time.Second}
+
+	// 3. 记录开始时间
+	start := time.Now()
+	response, err := client.Get(serverURL)
+	if err != nil {
+		return 0, fmt.Errorf("download failed: %w", err)
+	}
+	defer response.Body.Close()
+
+	// 4. 确保响应状态码为200
+	if response.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("server error: status code %d", response.StatusCode)
+	}
+
+	// 5. 计算接收字节数并丢弃数据
+	totalBytes, err := io.Copy(io.Discard, response.Body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// 6. 计算时间和速度
+	duration := time.Since(start).Seconds()
+	if duration == 0 || totalBytes == 0 {
+		return 0, fmt.Errorf("invalid measurement: duration=%f, bytes=%d", duration, totalBytes)
+	}
+
+	// 7. 返回Mbps速度
+	speed := (float64(totalBytes) * 8) / (duration * 1024 * 1024)
+	return speed, nil
+}
+
+func testUploadSpeed(serverUrl string, credentials Credentials) (float64, error) {
+	fmt.Println("Starting upload speed test to:", serverUrl)
+
+	if !isValid(serverUrl) {
+		return 0, fmt.Errorf("invalid URL: %s", serverUrl)
+	}
+
+	ftpServer := strings.TrimPrefix(serverUrl, "ftp://") + ":21"
+	fmt.Printf("Connecting to FTP server: %s\n", ftpServer)
+
+	ftpClient, err := ftp.Dial(ftpServer, ftp.DialWithTimeout(5*time.Second))
+	if err != nil {
+		return 0, fmt.Errorf("failed to connect to FTP server: %w", err)
+	}
+	defer ftpClient.Quit()
+
+	fmt.Printf("Attempting login with username: %s\n", credentials.userName)
+	err = ftpClient.Login(credentials.userName, credentials.password)
+	if err != nil {
+		return 0, fmt.Errorf("failed to login to FTP server: %w", err)
+	}
+	fmt.Println("Successfully logged in to FTP server")
+
+	// Create test data (100MB)
+	dataSize := 100 * 1024 * 1024 // 100MB
+	fmt.Printf("Preparing %d MB of test data\n", dataSize/1024/1024)
+	data := make([]byte, dataSize)
+	for i := range data {
+		data[i] = 'A'
+	}
+
+	testFileName := fmt.Sprintf("speedtest_%d.dat", time.Now().Unix())
+	fmt.Printf("Starting upload of test file: %s\n", testFileName)
+
+	start := time.Now()
+	err = ftpClient.Stor(testFileName, bytes.NewReader(data))
+	if err != nil {
+		return 0, fmt.Errorf("failed to upload file: %w", err)
+	}
+
+	duration := time.Since(start).Seconds()
+	uploadSpeed := (float64(len(data)) * 8 / duration) / (1024 * 1024)
+	fmt.Printf("Upload completed in %.2f seconds\n", duration)
+
+	fmt.Printf("Cleaning up - deleting test file: %s\n", testFileName)
+	err = ftpClient.Delete(testFileName)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete test file: %w", err)
+	}
+
+	fmt.Printf("Raw upload speed calculated: %.2f Mbps\n", uploadSpeed)
+	return uploadSpeed, nil
+}
+
+type Credentials struct {
+	userName string
+	password string
+}

--- a/cmd/speedtest_test.go
+++ b/cmd/speedtest_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDownloadSpeed(t *testing.T) {
+	// Create test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Send 1MB of test data
+		data := make([]byte, 1024*1024)
+		for i := range data {
+			data[i] = 'A'
+		}
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	// Test valid URL
+	speed, err := testDownloadSpeed(ts.URL)
+	if err != nil {
+		t.Errorf("testDownloadSpeed failed: %v", err)
+	}
+	if speed <= 0 {
+		t.Errorf("Expected positive speed, got %f", speed)
+	}
+
+	// Test invalid URL
+	_, err = testDownloadSpeed("invalid-url")
+	if err == nil {
+		t.Error("Expected error for invalid URL but got nil")
+	}
+
+	// Test server error
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts2.Close()
+
+	_, err = testDownloadSpeed(ts2.URL)
+	if err == nil {
+		t.Error("Expected error for server error but got nil")
+	}
+}
+
+// TODO: find a way to mock FTP server and test it

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,11 @@ require golang.org/x/net v0.33.0
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jlaffaye/ftp v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,17 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jlaffaye/ftp v0.2.0 h1:lXNvW7cBu7R/68bknOX3MrRIIqZ61zELs1P2RAiA3lg=
+github.com/jlaffaye/ftp v0.2.0/go.mod h1:is2Ds5qkhceAPy2xD6RLI6hmp/qysSoymZ+Z2uTnspI=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=


### PR DESCRIPTION
This pull request introduces a new feature to perform an internet speed test and includes the necessary changes to support this functionality. The main changes involve adding a new command to the CLI, implementing the speed test logic, and including tests for the download speed functionality.

New feature implementation:

* [`cmd/speedtest.go`](diffhunk://#diff-c0f370e0dc3fa5d8fe2111d746abb4dd089002a781c7931f9c7857b3eae12d98R1-R166): Added a new command `speedtest` to perform internet speed tests, including functions to test download and upload speeds. The download speed is measured using HTTP requests, while the upload speed is measured using FTP uploads.

Testing:

* [`cmd/speedtest_test.go`](diffhunk://#diff-a9adbbf238f392aa8d13d02d336dd8df06750a32ba0ad745e3afcb704f8c55a2R1-R48): Added tests for the `testDownloadSpeed` function, including cases for valid URLs, invalid URLs, and server errors.

Dependencies:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R9-R13): Added new dependencies `github.com/hashicorp/errwrap`, `github.com/hashicorp/go-multierror`, and `github.com/jlaffaye/ftp` to support the new speed test functionality.